### PR TITLE
Fix some mappings

### DIFF
--- a/SrcomLib/Mapping/Converters/CategoryListConverter.cs
+++ b/SrcomLib/Mapping/Converters/CategoryListConverter.cs
@@ -28,6 +28,7 @@ namespace SrcomLib.Mapping.Converters
                 cfg.CreateMap<List<apiSub.Link>, IReadOnlyList<resSub.Link>>().ConvertUsing<LinkListConverter>();
                 cfg.CreateMap<string, resSub.CategoryType>().ConvertUsing<CategoryTypeConverter>();
                 cfg.CreateMap<List<api.Variable>, IReadOnlyList<res.Variable>>().ConvertUsing<VariableListConverter>();
+                cfg.CreateMap<string, resSub.PlayersType>().ConvertUsing<PlayersTypeConverter>();
             });
             var mapper = new Mapper(config);
 

--- a/SrcomLib/Mapping/Converters/VideosConverter.cs
+++ b/SrcomLib/Mapping/Converters/VideosConverter.cs
@@ -10,6 +10,11 @@ namespace SrcomLib.Mapping.Converters
     {
         public IReadOnlyList<Uri> Convert(Videos source, IReadOnlyList<Uri> destination, ResolutionContext context)
         {
+            if (source is null || source.Links is null)
+            {
+                return default;
+            }
+            
             var config = new MapperConfiguration(cfg =>
             {
                 cfg.CreateMap<BasicLink, Uri>().ConvertUsing<UriBasicLinkConverter>();


### PR DESCRIPTION
When retrieving a leaderboard, we would sometimes get an AutoMapper exception for any run that does not have a video. This is because we are missing a null-check on "source" in the VideosConverter. Handling "source is null" fixed the problem for SOME affected runs... but I did find some edge cases where, for some reason, source was NOT null, but source.Links was. Adding the additional null check fixes those additional problems.

When searching games and embedding categories, we would sometimes get an AutoMapper exception for any categories that allow "up to" a certain number of players (rather than requiring an exact number). This is because we were not using the PlayersTypeConverter for this embed. This likely went unnoticed because there are only two options for the PlayersType enum: "exactly" and "up-to". If the SRC API reports a value of "exactly" (by far the more common value among SRC categories), then AutoMapper's default behavior of Enum.TryParse gives us the correct value. It is only when SRC reports a value of "up-to" that we would get an error. Using the PlayersTypeConverter fixes this problem.